### PR TITLE
Update v3.26.2

### DIFF
--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -193,8 +193,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-documents/3.26/gnome-documents-3.26.1.tar.xz",
-                    "sha256": "ba0d3084359d666b90733bb43206d24190fa85304bfe45f674ab6e6a27cb7fc9"
+                    "url": "https://download.gnome.org/sources/gnome-documents/3.26/gnome-documents-3.26.2.tar.xz",
+                    "sha256": "24c794718329bc2d0ccd303461941de4ebe30da95b495dead615c3ba2bb8eb60"
                 }
             ]
         }


### PR DESCRIPTION
3.26.2 - "Zala"
===============

- Use 'var' for symbols that are exported
- Use the standard dialect of String.prototype.replace
- Explicitly specify the Gepub API version
- Translation updates