### PR TITLE
Update from split-off gnome-books

### DIFF
--- a/0001-build-Fix-build-order-with-libtracker-sparql-generat.patch
+++ b/0001-build-Fix-build-order-with-libtracker-sparql-generat.patch
@@ -1,0 +1,49 @@
+From a452173ed5a68d31c9a7a7dc10212eabbd9e073a Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Tue, 6 Nov 2018 11:36:52 +0100
+Subject: [PATCH] build: Fix build order with libtracker-sparql generated
+ headers
+
+Both libtracker-fts and libtracker-data end up requiring includes
+from tracker-sparql.h, but we have to generate tracker-generated.h
+first.
+
+It's pretty terrible to add intermediate targets as a dependency
+outside the libtracker-sparql directory, but it doesn't seem we
+can do better.
+
+Closes: https://gitlab.gnome.org/GNOME/tracker/issues/52
+---
+ src/libtracker-data/meson.build | 2 +-
+ src/libtracker-fts/meson.build  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libtracker-data/meson.build b/src/libtracker-data/meson.build
+index d5c384b2b..ae4487496 100644
+--- a/src/libtracker-data/meson.build
++++ b/src/libtracker-data/meson.build
+@@ -73,7 +73,7 @@ libtracker_data = library('tracker-data',
+     # symbols from libtracker-sparql, but does not mean it should
+     # be linked to it.
+     override_options: ['b_lundef=false'],
+-    dependencies: tracker_data_dependencies + [unicode_library],
++    dependencies: tracker_data_dependencies + [unicode_library, tracker_sparql_intermediate_dep],
+     include_directories: [commoninc, configinc, srcinc],
+ )
+ 
+diff --git a/src/libtracker-fts/meson.build b/src/libtracker-fts/meson.build
+index 5ab4409f8..1392699f8 100644
+--- a/src/libtracker-fts/meson.build
++++ b/src/libtracker-fts/meson.build
+@@ -11,7 +11,7 @@ libtracker_fts = static_library('tracker-fts',
+     'tracker-fts-config.c',
+     'tracker-fts-tokenizer.c',
+     libtracker_fts_fts5,
+-    dependencies: [tracker_common_dep],
++    dependencies: [tracker_common_dep, tracker_sparql_intermediate_dep],
+     c_args: tracker_c_args
+ )
+ 
+-- 
+2.20.1
+

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -14,9 +14,10 @@
         "--filesystem=xdg-documents:ro", "--filesystem=xdg-download:ro",
         /* Needs to talk to the network: */
         "--share=network",
-        /* Tracker access */
+        /* Tracker D-Bus access */
         "--talk-name=org.freedesktop.Tracker1",
         "--talk-name=org.freedesktop.Tracker1.Miner.Extract",
+        "--env=TRACKER_SPARQL_BACKEND=bus",
         /* Needed for dconf to work */
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -183,7 +183,9 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/gnome-books.git"
+                    "url": "https://gitlab.gnome.org/GNOME/gnome-books.git",
+                    "tag": "3.31.90",
+                    "commit": "1f08878dead80f09070f15cf6e8c1a0c3cf6e1e7"
                 }
             ]
         }

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -129,6 +129,10 @@
                     "url": "https://gitlab.gnome.org/GNOME/tracker.git",
                     "tag": "2.1.6",
                     "commit": "e3dc415c9c71515a7402327c0d1b612f1ade042f"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-build-Fix-build-order-with-libtracker-sparql-generat.patch"
                 }
             ]
         },

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -18,6 +18,8 @@
         "--talk-name=org.freedesktop.Tracker1",
         "--talk-name=org.freedesktop.Tracker1.Miner.Extract",
         "--env=TRACKER_SPARQL_BACKEND=bus",
+        /* For the WebP loader */
+        "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
         /* Needed for dconf to work */
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
@@ -38,6 +40,21 @@
                     "tag": "3.30.2",
                     "commit": "8b7e4d1986450c4991e03de6b32bc98ee4f13c21"
                 }
+            ]
+        },
+        {
+            "name": "webp-pixbuf-loader",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/aruiz/webp-pixbuf-loader.git",
+                    "commit": "9b92950d49d7939f90ba7413deb7ec6b392b2054"
+                }
+            ],
+            "post-install": [
+                "GDK_PIXBUF_MODULEDIR=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/ gdk-pixbuf-query-loaders > loaders.cache",
+                "cat /usr/lib/*/gdk-pixbuf-2.0/2.10.0/loaders.cache loaders.cache > /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
             ]
         },
         {

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -21,79 +21,21 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "env": {
-            "V": "1"
-        }
-    },
-    "cleanup": ["/include", "/lib/pkgconfig",
-                "/share/pkgconfig", "/share/aclocal",
-                "/man", "/share/man", "/share/gtk-doc",
-                "/share/vala",
-                "*.la", "*.a",
-                "/bin/gnome-documents"],
+    "cleanup": [ "/include", "/lib/pkgconfig",
+                 "/share/pkgconfig", "/share/aclocal",
+                 "/man", "/share/man", "/share/gtk-doc",
+                 "/share/vala",
+                 "*.la", "*.a" ],
     "modules": [
-        {
-            "name": "librest",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/rest/0.8/rest-0.8.1.tar.xz",
-                    "sha256": "0513aad38e5d3cedd4ae3c551634e3be1b9baaa79775e53b2dba9456f15b01c9"
-                }
-            ]
-        },
-        {
-            "name": "gnome-online-accounts",
-            "config-opts": ["--disable-telepathy", "--disable-documentation", "--disable-backend", "--disable-Werror" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.30/gnome-online-accounts-3.30.0.tar.xz",
-                    "sha256": "27d9d88942aa02a1f8d003dfe515483d8483f216ba1e297a8ef67a42cf4bcfc3"
-                }
-            ]
-        },
         {
             "name": "gnome-desktop",
             "config-opts": ["--disable-debug-tools", "--disable-udev"],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/3.30/gnome-desktop-3.30.1.tar.xz",
-                    "sha256": "1383703bedd71204e4a161fb163905410c8f651890f18b3fa8405506ba97789f"
-                }
-            ]
-        },
-        {
-            "name": "liboauth",
-            "config-opts": [ "--enable-nss" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://netix.dl.sourceforge.net/project/liboauth/liboauth-1.0.3.tar.gz",
-                    "sha256": "0df60157b052f0e774ade8a8bac59d6e8d4b464058cc55f9208d72e41156811f"
-                }
-            ]
-        },
-        {
-            "name": "libgdata",
-            "config-opts": ["--disable-always-build-tests", "--disable-Werror", "--disable-static" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgdata/0.17/libgdata-0.17.9.tar.xz",
-                    "sha256": "85c4f7674c0098ffaf060ae01b6b832cb277b3673d54ace3bdedaad6b127453a"
-                }
-            ]
-        },
-        {
-            "name": "libzapojit",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libzapojit/0.0/libzapojit-0.0.3.tar.xz",
-                    "sha256": "3d25f99329105abb99d1e9651b0aa1842065456ea54c22970a7330e9f3d1c37e"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gnome-desktop.git",
+                    "tag": "3.30.2",
+                    "commit": "8b7e4d1986450c4991e03de6b32bc98ee4f13c21"
                 }
             ]
         },
@@ -135,9 +77,10 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.1.tar.xz",
-                    "sha256": "819a1d23c7603000e73f5e738bdd284342e0cd345fb0c7650999c31ec741bbe5"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gspell.git",
+                    "tag": "1.8.1",
+                    "commit": "ba03499234037861e01ce1e83075e8a32b9790f3"
                 }
             ]
         },
@@ -150,47 +93,45 @@
                              "--enable-comics" ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/evince/3.30/evince-3.30.1.tar.xz",
-                    "sha256": "abc5516848e743bd79645e9693250974ffd5235617dd746c83b67c4c671ac0b7"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/evince.git",
+                    "tag": "3.30.2",
+                    "commit": "d1cef98aecbc490dbea72323e4e75af5fcc2f5d8"
                 }
             ]
         },
         {
-            "name" : "tracker",
-            "config-opts" : [
-                "--disable-miner-apps",
-                "--disable-static",
-                "--disable-tracker-extract",
-                "--disable-tracker-needle",
-                "--disable-tracker-preferences",
-                "--disable-artwork",
-                "--disable-tracker-writeback",
-                "--disable-miner-user-guides",
-                "--with-bash-completion-dir=no"
-            ],
-            "sources" : [
+            "name": "tracker",
+            "buildsystem": "meson",
+            "cleanup": [ "/bin", "/etc", "/lib/systemd", "/libexec", "/share/dbus-1/services" ],
+            "config-opts": [ "--default-library=shared", "-Dbash-completion=no", "-Ddocs=false", "-Dsystemd_user_services=no" ],
+            "sources": [
                 {
-                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/tracker/2.1/tracker-2.1.5.tar.xz",
-                    "sha256" : "b234b7573773b904dc3e885ff5ec44e86b035767cde783bc50d65d12cd72861e"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/tracker.git",
+                    "tag": "2.1.6",
+                    "commit": "e3dc415c9c71515a7402327c0d1b612f1ade042f"
                 }
             ]
         },
         {
             "name": "tracker-miners",
+            "buildsystem": "meson",
             "cleanup": [ "/bin", "/etc", "/lib/systemd", "/libexec" ],
-            "config-opts": [ "--disable-miner-apps",
-                             "--disable-miner-rss",
-                             "--disable-static",
-                             "--disable-tracker-extract",
-                             "--disable-tracker-writeback",
-                             "--enable-miner-fs" ],
+            "config-opts": [ "--default-library=shared",
+                             "-Dminer_apps=false",
+                             "-Dminer_rss=false",
+                             "-Dextract=false",
+                             "-Dgeneric_media_extractor=none",
+                             "-Dwriteback=false",
+                             "-Dminer_fs=true",
+                             "-Ddbus_services=/app/share/dbus-1/services/" ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/tracker-miners/2.1/tracker-miners-2.1.5.tar.xz",
-                    "sha256": "f5fd3d4b5573539554d5982ee8ecc10ea84f6693378c5bcc7b162096a63bb8cd"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/tracker-miners.git",
+                    "tag": "2.1.5",
+                    "commit": "84321f0e1468175c92da92006a2e960fba22a359"
                 }
             ]
         },
@@ -199,9 +140,10 @@
             "buildsystem": "meson",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgepub/0.6/libgepub-0.6.0.tar.xz",
-                    "sha256": "c78a395cc1d9c57b4485958ed83ffb96ed442750cfafa7797dd6d986b9f7b399"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libgepub.git",
+                    "tag": "0.6.0",
+                    "commit": "ecca0e1e8f2c301b1ea769e618a92125ee934b57"
                 }
             ]
         },
@@ -209,9 +151,10 @@
             "name": "gnome-epub-thumbnailer",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-epub-thumbnailer/1.5/gnome-epub-thumbnailer-1.5.tar.xz",
-                    "sha256": "308210f5800219f64cae4828e59bb8e6e4c53b888048cf487221aeb4337d791a"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer.git",
+                    "tag": "1.5",
+                    "commit": "cce8d8e594ef8fe77720ca33656c2f4368cd424a"
                 }
             ]
         },
@@ -221,9 +164,8 @@
             "config-opts": [ "-Denable-documentation=false" ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-documents/3.30/gnome-documents-3.30.1.tar.xz",
-                    "sha256": "66191078f42adf50e4aa4cfba5a6564afd17e26f2c8fb3d71acd7b2ea29b0ffd"
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gnome-books.git"
                 }
             ]
         }


### PR DESCRIPTION
Remove unused build options, switch to git commits for most GNOME-hosted
modules (rather than tarballs), remove obsolete deps.