### PR TITLE
Remove gspell dependency

### DIFF
--- a/add-missing-appdata-elements.patch
+++ b/add-missing-appdata-elements.patch
@@ -1,0 +1,57 @@
+From e73364a2ddef972f6007eac023677cc7e060eab3 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Thu, 1 Aug 2019 14:38:20 +0200
+Subject: [PATCH 1/2] appdata: Add <translation> element
+
+---
+ data/org.gnome.Books.appdata.xml.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/org.gnome.Books.appdata.xml.in b/data/org.gnome.Books.appdata.xml.in
+index f0a79c01..0d9a9f69 100644
+--- a/data/org.gnome.Books.appdata.xml.in
++++ b/data/org.gnome.Books.appdata.xml.in
+@@ -41,6 +41,7 @@
+     </screenshot>
+   </screenshots>
+   <update_contact>hadess_at_gnome.org</update_contact>
++  <translation type="gettext">gnome-books</translation>
+   <content_rating type="oars-1.1">
+     <content_attribute id="violence-cartoon">none</content_attribute>
+     <content_attribute id="violence-fantasy">none</content_attribute>
+-- 
+2.21.0
+
+
+From 4889d95d8c75e78c8f769b029877420bcff9f9ef Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Thu, 1 Aug 2019 14:39:31 +0200
+Subject: [PATCH 2/2] appdata: Add release information
+
+---
+ data/org.gnome.Books.appdata.xml.in | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/data/org.gnome.Books.appdata.xml.in b/data/org.gnome.Books.appdata.xml.in
+index 0d9a9f69..0009f98f 100644
+--- a/data/org.gnome.Books.appdata.xml.in
++++ b/data/org.gnome.Books.appdata.xml.in
+@@ -42,6 +42,15 @@
+   </screenshots>
+   <update_contact>hadess_at_gnome.org</update_contact>
+   <translation type="gettext">gnome-books</translation>
++  <releases>
++    <release version="3.32.0" date="2019-03-08">
++      <description>
++        <p>
++          We are proud to announce Books 3.32.0 as the latest stable version.
++        </p>
++      </description>
++    </release>
++  </releases>
+   <content_rating type="oars-1.1">
+     <content_attribute id="violence-cartoon">none</content_attribute>
+     <content_attribute id="violence-fantasy">none</content_attribute>
+-- 
+2.21.0
+

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -92,27 +92,14 @@
             ]
         },
         {
-            "name": "gspell",
-            "cleanup": [
-                "/bin"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/gspell.git",
-                    "tag": "1.8.1",
-                    "commit": "ba03499234037861e01ce1e83075e8a32b9790f3"
-                }
-            ]
-        },
-        {
             "name": "evince",
             "buildsystem": "meson",
             "cleanup": [ "/share/GConf", "/share/help" ],
             "config-opts": [ "-Dnautilus=false", "-Dviewer=false",
                              "-Dpreviewer=false", "-Ddbus=false",
                              "-Dbrowser_plugin=false", "-Dintrospection=true",
-                             "-Dcomics=enabled", "-Dpdf=enabled" ],
+                             "-Dcomics=enabled", "-Dpdf=enabled",
+                             "-Dgspell=disabled" ],
             "sources": [
                 {
                     "type": "git",

--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -175,6 +175,10 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gnome-books.git",
                     "commit": "61f85f3c63e31d331417ee0dba899a052107510e"
+                },
+                {
+                    "type": "patch",
+                    "path": "add-missing-appdata-elements.patch"
                 }
             ]
         }


### PR DESCRIPTION
It's not needed as gspell is only used in annotations and we don't show
those.

See https://gitlab.gnome.org/GNOME/gnome-books/merge_requests/25