### PR TITLE
Build poppler with boost. Don't build binaries

### DIFF
--- a/org.gnome.Books.json
+++ b/org.gnome.Books.json
@@ -27,6 +27,24 @@
     ],
     "modules": [
         {
+            "name": "boost",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/include",
+                "mv boost ${FLATPAK_DEST}/include"
+            ],
+            "cleanup": [
+                "/include"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2",
+                    "sha256": "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402"
+                }
+            ]
+        },
+        {
             "name": "gnome-desktop",
             "buildsystem": "meson",
             "config-opts": [
@@ -85,7 +103,9 @@
                 "-DCMAKE_INSTALL_LIBDIR=/app/lib",
                 "-DCMAKE_INSTALL_INCLUDEDIR=/app/include",
                 "-DENABLE_LIBOPENJPEG=none",
-                "-DENABLE_BOOST=OFF"
+                "-DBUILD_CPP_TESTS=OFF",
+                "-DBUILD_GTK_TESTS=OFF",
+                "-DENABLE_UTILS=OFF"
             ],
             "cleanup": [
                 "/bin"


### PR DESCRIPTION
I couldn't figure out if the Splash backend was used or not, as Books doesn't seem to want to show me my PDF, but libevince references it. Instead I enabled boost.

The reason for boost is, with a header only, to fix a big performance issue with the splash backend. boost is not opt-out if you build the splash backend.